### PR TITLE
Dynamic Buttons & Lists - Click event fix

### DIFF
--- a/src/pages.js
+++ b/src/pages.js
@@ -277,8 +277,6 @@ App._Pages = function (window, document, Clickable, Scrollable, App, Utils, Even
 
 		fixContentHeight(page);
 
-		Utils.forEach(page.querySelectorAll('.app-button'), attachButtonEvent);
-
 		//Attach click events for buttons added later on
 		page.addEventListener('DOMNodeInserted', function (e) {
 			var element = e.srcElement;
@@ -288,6 +286,9 @@ App._Pages = function (window, document, Clickable, Scrollable, App, Utils, Even
 		});
 
 		populatePage(pageName, pageManager, page, args);
+
+		//-Apply click events to buttons on 'page' AFTER it's populated
+		Utils.forEach(page.querySelectorAll('.app-button'), attachButtonEvent);
 
 		page.addEventListener(eventTypeToName(EVENTS.SHOW), function () {
 			setTimeout(function () {


### PR DESCRIPTION
Fixes a bug where dynamically added buttons (through App.controller) do not get click events added.

`App.controller('page1', function (page)
{
  var data = 'Page 2';
  $(page).find('#somelist').append('<li class="app-button" data-target="page2">' + data + '</li>');
});
`

Applying click events after populatePages() (instead of before), fixes this.